### PR TITLE
launch jekyll (both serve, and build) through bundle exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start": "npm run css && npm-run-all -p css-watch jekyll",
     "css": "postcss assets/css/main.css -o _includes/main.css",
     "css-watch": "npm run css -- -w true",
-    "jekyll": "jekyll server --drafts",
-    "build": "jekyll build",
+    "jekyll": "bundle exec jekyll server --drafts",
+    "build": "bundle exec jekyll build",
     "browsersync": "browser-sync start --proxy localhost:4000 --files='_site'",
     "deploy": "npm run build && node deploy"
   },


### PR DESCRIPTION
Hi @AgtLucas, I plan to start blogging soon as my new year resolution
and I came across with your blog some time ago, 
you got a great typesetting there, awesome work!

I'll use your theme with some minor modifications for my blog, but, i'll give you the credits for it, 
thanks for licensing it under MIT :D 

Btw, going to the point: you apparently broke the build with the `public_suffix` gem:

```
WARN: Unresolved specs during Gem::Specification.reset:
      jekyll-watch (~> 1.1)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
/home/onlurking/.gem/ruby/2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:313:in `check_for_activated_spec!': You have already activated public_suffix 3.0.1, but your Gemfile requires public_suffix 3.0.0. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
	from /home/onlurking/.gem/ruby/2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:31:in `block in setup'
	from /usr/lib/ruby/2.4.0/forwardable.rb:229:in `each'
	from /usr/lib/ruby/2.4.0/forwardable.rb:229:in `each'
	from /home/onlurking/.gem/ruby/2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:26:in `map'
	from /home/onlurking/.gem/ruby/2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:26:in `setup'
	from /home/onlurking/.gem/ruby/2.4.0/gems/bundler-1.16.1/lib/bundler.rb:107:in `setup'
	from /home/onlurking/.gem/ruby/2.4.0/gems/jekyll-3.6.2/lib/jekyll/plugin_manager.rb:50:in `require_from_bundler'
	from /home/onlurking/.gem/ruby/2.4.0/gems/jekyll-3.6.2/exe/jekyll:11:in `<top (required)>'
	from /home/onlurking/.gem/ruby/2.4.0/bin/jekyll:23:in `load'
	from /home/onlurking/.gem/ruby/2.4.0/bin/jekyll:23:in `<main>'
error Command failed with exit code 1.
```

This PR fix the build by just launching jekyll through bundle exec.